### PR TITLE
chore: establish some coding style standards

### DIFF
--- a/{{ cookiecutter.project_slug }}/.editorconfig
+++ b/{{ cookiecutter.project_slug }}/.editorconfig
@@ -1,0 +1,20 @@
+# https://editorconfig.org/
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.py]
+max_line_length = 88
+
+[*.md]
+max_line_length = 79
+
+[*.yml]
+indent_size = 2


### PR DESCRIPTION
See https://editorconfig.org/ for more information.

I found myself adding this file each time after after creating a new project with this skeleton. So I thought: why not add this to the source. I am open to different settings (or additional ones). My main goal is to have this in each repository and establish a standard to make code written by multiple developers a bit more consistent, without them having to think about it because the editor does the right thing automatically.

I've taken the current Django `.editorconfig` file (source: https://github.com/django/django/blob/main/.editorconfig) as the basis and modified it slightly:

- Ordered the settings alphabetically
- Removed unused file types (.html, Makefile, etc)
- Added Markdown (.md)

Note that the max line length for Python files (88) matches the default line length setting of Ruff.